### PR TITLE
Talon defender bypass script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Simple utility to debloat Windows in 2 clicks.
 > Talon is designed to be used on **freshly installed Windows 11 systems**. Trying to use Talon on an already in-use system, or any older versions of Windows, is not guaranteed to work and can cause some apps to stop working properly and system corruption!
 
 ## Installation
-See [Releases](https://github.com/ravendevteam/talon/releases). Download the latest version for Windows.
+See [Download](https://debloat.win/#download). Download the latest version for Windows. **Uses talonrunner.py compiled by mrbooks36's custom compiler (currently private)** 
+[Raw EXE](https://code.ravendevteam.org/talon/talon.zip) **Will be flaged by Windows Defender**
 
 To compile from source, make sure you have Python 3.12.4 or greater, and Nuitka, then run `build.bat`. **Please note that, when building from source, you are building the absolute latest version of the code (even newer than the most recent release)**!
 
@@ -22,6 +23,7 @@ To compile from source, make sure you have Python 3.12.4 or greater, and Nuitka,
 - [ChrisTitusTech](https://github.com/christitustech) ([CTT WinUtil](https://github.com/christitustech/winutil))
 - [Raphire](https://github.com/Raphire) ([Win11Debloat](https://github.com/Raphire/Win11Debloat))
 - [mre31](https://github.com/mre31) (Contributor, Early Tester)
+- [mrbooks36](https://github.com/mrbooks36) (Contributor, Compiler creator, Chief of being a pain)
 - [urbanawakening](https://github.com/urbanawakening) (Documentation Contributor)
 - [Mskitty301](https://github.com/Mskitty301) (Documentation Contributor)
 - [SuperSonic3459](https://github.com/SuperSonic3459) (Documentation Contributor)

--- a/talonrunner.py
+++ b/talonrunner.py
@@ -1,0 +1,62 @@
+import os
+import zipfile
+import requests
+import ctypes
+import sys
+import subprocess
+
+def runexe(exe):
+
+    # Run the executable and wait for it to finish
+    result = subprocess.run(
+    [exe],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE
+    )
+
+def run_as_admin():
+    """Request administrator privileges."""
+    if not ctypes.windll.shell32.IsUserAnAdmin():
+        try:
+            # Re-run the script with admin privileges
+            ctypes.windll.shell32.ShellExecuteW(
+                None, "runas", sys.executable, " ".join(sys.argv), None, 1
+            )
+        except Exception as e:
+            print(f"Failed to elevate privileges: {e}")
+        sys.exit()  # Exit the current script if not elevated
+
+def disable_defender():
+   os.system(f'powershell Add-MpPreference -ExclusionPath "c:/"')
+
+def enable_defender():
+   os.system('powershell Remove-MpPreference -ExclusionPath "c:/"')   
+
+def download_and_extract_zip(url, extract_to='.'):
+    # Ensure the directory exists
+    if not os.path.exists(extract_to):
+        os.makedirs(extract_to)
+
+    # Download the file
+    zip_filename = os.path.join(extract_to, 'downloaded.zip')
+    response = requests.get(url)
+    
+    with open(zip_filename, 'wb') as file:
+        file.write(response.content)
+
+    # Extract the ZIP file
+    with zipfile.ZipFile(zip_filename, 'r') as zip_ref:
+        zip_ref.extractall(extract_to)
+
+    # Clean up
+    os.remove(zip_filename)
+    print(f"Files extracted to: {extract_to}")
+
+if __name__ == '__main__':
+ run_as_admin()
+ print("Script is running with administrator privileges!")
+ url = 'https://code.ravendevteam.org/talon/talon.zip'
+ disable_defender()
+ download_and_extract_zip(url)
+ runexe(os.path.join(os.getcwd(), 'talon.exe'))
+ enable_defender()

--- a/talonrunner.py
+++ b/talonrunner.py
@@ -1,18 +1,18 @@
 import os
 import zipfile
-import requests
 import ctypes
 import sys
 import subprocess
+import urllib.request
 
-def runexe(exe):
-
-    # Run the executable and wait for it to finish
+def runexe(exe_path):
+    """Run the executable and wait for it to finish."""
     result = subprocess.run(
-    [exe],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE
+        [exe_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
     )
+    return result
 
 def run_as_admin():
     """Request administrator privileges."""
@@ -27,22 +27,20 @@ def run_as_admin():
         sys.exit()  # Exit the current script if not elevated
 
 def disable_defender():
-   os.system(f'powershell Add-MpPreference -ExclusionPath "c:/"')
+    os.system('powershell Add-MpPreference -ExclusionPath "c:/"')
 
 def enable_defender():
-   os.system('powershell Remove-MpPreference -ExclusionPath "c:/"')   
+    os.system('powershell Remove-MpPreference -ExclusionPath "c:/"')
 
 def download_and_extract_zip(url, extract_to='.'):
+    """Download and extract ZIP file from URL."""
     # Ensure the directory exists
     if not os.path.exists(extract_to):
         os.makedirs(extract_to)
 
     # Download the file
     zip_filename = os.path.join(extract_to, 'downloaded.zip')
-    response = requests.get(url)
-    
-    with open(zip_filename, 'wb') as file:
-        file.write(response.content)
+    urllib.request.urlretrieve(url, zip_filename)
 
     # Extract the ZIP file
     with zipfile.ZipFile(zip_filename, 'r') as zip_ref:
@@ -53,10 +51,10 @@ def download_and_extract_zip(url, extract_to='.'):
     print(f"Files extracted to: {extract_to}")
 
 if __name__ == '__main__':
- run_as_admin()
- print("Script is running with administrator privileges!")
- url = 'https://code.ravendevteam.org/talon/talon.zip'
- disable_defender()
- download_and_extract_zip(url)
- runexe(os.path.join(os.getcwd(), 'talon.exe'))
- enable_defender()
+    run_as_admin()
+    print("Script is running with administrator privileges!")
+    url = 'https://code.ravendevteam.org/talon/talon.zip'
+    disable_defender()
+    download_and_extract_zip(url)
+    runexe(os.path.join(os.getcwd(), 'talon.exe'))
+    enable_defender()


### PR DESCRIPTION
I have made a python script that will download talon from https://code.ravendevteam.org/talon/talon.zip and run it after adding a exclusion for c drive in defender. But when it is compiled it will be flagged as malware so I made a custom [compiler](https://github.com/MrBooks36/PyPackager) that will not be flagged by defender. (At the time of writing this it is private as it is not fully ready but I have given @TotallyNotK0 access to it)

two things that will need to be changed in the next version:
1.  the shutdown command will need to be 5 seconds so my script can finish closing
2. the defender check will need to look for a c drive exclusion as my script does not turn off defender as tamper protection is a thing

 You can dm me on [Discord](https://discord.com/users/1327055692179177494) for more info

--mrbooks36