### PR TITLE
Fix/winutil patch

### DIFF
--- a/debloat_components/debloat_execute_external_scripts.py
+++ b/debloat_components/debloat_execute_external_scripts.py
@@ -83,14 +83,6 @@ def main():
         except Exception:
             pass
         sys.exit(1)
-    finally:
-        # Clean up the temporary patched WinUtil script
-        try:
-            if os.path.exists(winutil_temp_path):
-                os.remove(winutil_temp_path)
-                logger.info(f"Removed temporary file: {winutil_temp_path}")
-        except Exception as e:
-            logger.warning(f"Failed to remove temporary file {winutil_temp_path}: {e}")
     args2 = [
         '-Silent',
         '-RemoveApps',

--- a/utilities/util_download_handler.py
+++ b/utilities/util_download_handler.py
@@ -40,7 +40,11 @@ def download_file(
     for attempt in range(1, retries + 1):
         try:
             logger.info(f"Attempt {attempt}/{retries}: Downloading {url} to {dest_path}")
-            with urllib.request.urlopen(url, context=ssl_context) as response, open(dest_path, "wb") as out_file:
+            req = urllib.request.Request(
+                url,
+                headers={'User-Agent': 'Mozilla/5.0 (Windows NT 11.0; Win64; x64)'}
+            )
+            with urllib.request.urlopen(req, context=ssl_context) as response, open(dest_path, "wb") as out_file:
                 out_file.write(response.read())
             logger.info(f"Successfully downloaded {url} to {dest_path}")
             return True


### PR DESCRIPTION
## Description
Fix to issue #154 by patching the WinUtil script to remove the unwanted warning Invoke-WPFFeatureInstall pop-up. 

## Changes
- Added regex-based patching to remove the feature installation block from WinUtil.
Before regex patch:
```powershell
    # maybe this is not the best place to load and execute config file?
    # maybe community can help?
    if ($PARAM_CONFIG) {
        Invoke-WPFImpex -type "import" -Config $PARAM_CONFIG
        if ($PARAM_RUN) {
            while ($sync.ProcessRunning) {
                Start-Sleep -Seconds 5
            }
            Start-Sleep -Seconds 5

            Write-Host "Applying tweaks..."
            Invoke-WPFtweaksbutton
            while ($sync.ProcessRunning) {
                Start-Sleep -Seconds 5
            }
            Start-Sleep -Seconds 5
# START HERE
           Write-Host "Installing features..."
            Invoke-WPFFeatureInstall
            while ($sync.ProcessRunning) {
                Start-Sleep -Seconds 5
            }

            Start-Sleep -Seconds 5
            Write-Host "Installing applications..."
            while ($sync.ProcessRunning) {
                Start-Sleep -Seconds 1
            }
            Invoke-WPFInstall
            Start-Sleep -Seconds 5

           Write-Host "Done."
# END HERE
        }
    }

})
```

After the patch:
```powershell
    # maybe this is not the best place to load and execute config file?
    # maybe community can help?
    if ($PARAM_CONFIG) {
        Invoke-WPFImpex -type "import" -Config $PARAM_CONFIG
        if ($PARAM_RUN) {
            while ($sync.ProcessRunning) {
                Start-Sleep -Seconds 5
            }
            Start-Sleep -Seconds 5

            Write-Host "Applying tweaks..."
            Invoke-WPFtweaksbutton
            while ($sync.ProcessRunning) {
                Start-Sleep -Seconds 5
            }
            Start-Sleep -Seconds 5

        }
    }

})
```
- Updated download_file utility to use browser User-Agent to prevent HTTP 403 errors. We could use other methods like curl, but I wanted to use the already provided utility.
- Side-effect of the change: no progress bar on the Winutil UI. The only way to know something happened is to look at the logs.

## Testing
- Tested locally with `python -m debloat_components.debloat_execute_external_scripts`
- Tested with a built executable on a brand new Windows 11 Pro virtual machine on VMware Worksation 17 Pro 17.6.1
- Verified download works with User-Agent header (DOES NOT WORK WITHOUT)