### PR TITLE
Added two network related registry changes.

### DIFF
--- a/debloat_components/debloat_registry_tweaks.py
+++ b/debloat_components/debloat_registry_tweaks.py
@@ -35,6 +35,12 @@ def main():
         (winreg.HKEY_CURRENT_USER,
          r"Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced",
          "HideFileExt", winreg.REG_DWORD, 0),
+        (winreg.HKEY_LOCAL_MACHINE,
+         r"SOFTWARE\Policies\Microsoft\Windows\Psched",
+         "NonBestEffortLimit", winreg.REG_DWORD, 0),  # Disables reserved bandwith
+        (winreg.HKEY_LOCAL_MACHINE,
+         r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile",
+         "NetworkThrottlingIndex", winreg.REG_DWORD, 0xFFFFFFFF),  # Disables network throttling
     ]
     for hive, key_path, name, value_type, value in registry_modifications:
         try:


### PR DESCRIPTION
### Changes made

1. Disable bandwidth reservation: This removes Windows default behavior of reserving up to 20% of network bandwidth for system use, allowing all processes to share the full bandwidth more evenly.

2. Disable network throttling: This disables Windows network throttling mechanism, which may help reduce latency and improve responsiveness.

### Why?

I thought these changes would be helpful for systems with low bandwidth that need to squeeze every bit of speed they can get, but of course it can benefit anyone.