### PR TITLE
feat: allow custom arguments for Win11Debloat via config file

### DIFF
--- a/debloat_components/debloat_execute_external_scripts.py
+++ b/debloat_components/debloat_execute_external_scripts.py
@@ -10,165 +10,110 @@ from utilities.util_logger import logger
 from utilities.util_powershell_handler import run_powershell_command
 from utilities.util_error_popup import show_error_popup
 
-
-
 def _is_url(value: str) -> bool:
-	try:
-		p = urllib.parse.urlparse(value)
-		return p.scheme in ("http", "https") and bool(p.netloc)
-	except Exception:
-		return False
-
-
+    try:
+        p = urllib.parse.urlparse(value)
+        return p.scheme in ("http", "https") and bool(p.netloc)
+    except Exception:
+        return False
 
 def _download_config(url: str) -> str:
-	logger.info(f"Downloading WinUtil config from: {url}")
-	ctx = None
-	if url.lower().startswith("https"):
-		try:
-			import certifi
-			ctx = ssl.create_default_context(cafile=certifi.where())
-		except Exception:
-			ctx = ssl.create_default_context()
-	request = urllib.request.Request(url, headers={"User-Agent": "Talon/1.0"})
-	with urllib.request.urlopen(request, timeout=30, context=ctx) as resp:
-		data = resp.read()
-	try:
-		json.loads(data.decode("utf-8-sig"))
-	except Exception as e:
-		raise RuntimeError(f"Downloaded config is not valid JSON: {e}")
-	fd, tmp_path = tempfile.mkstemp(prefix="talon_winutil_", suffix=".json")
-	with os.fdopen(fd, "wb") as f:
-		f.write(data)
-	logger.info(f"Saved downloaded config to: {tmp_path}")
-	return tmp_path
+    logger.info(f"Downloading Config from: {url}")
+    ctx = None
+    if url.lower().startswith("https"):
+        try:
+            import certifi
+            ctx = ssl.create_default_context(cafile=certifi.where())
+        except Exception:
+            ctx = ssl.create_default_context()
+    request = urllib.request.Request(url, headers={"User-Agent": "Talon/1.0"})
+    with urllib.request.urlopen(request, timeout=30, context=ctx) as resp:
+        data = resp.read()
+    try:
+        json.loads(data.decode("utf-8-sig"))
+    except Exception as e:
+        raise RuntimeError(f"Downloaded config is not valid JSON: {e}")
+    fd, tmp_path = tempfile.mkstemp(prefix="talon_config_", suffix=".json")
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    logger.info(f"Saved downloaded config to: {tmp_path}")
+    return tmp_path
 
+def main(config_path=None):
+    if getattr(sys, 'frozen', False):
+        base_path = os.path.dirname(sys.executable)
+    else:
+        components_dir = os.path.dirname(os.path.abspath(__file__))
+        base_path = os.path.dirname(components_dir)
 
+    if config_path and isinstance(config_path, str) and _is_url(config_path):
+        try:
+            config_path = _download_config(config_path)
+        except Exception as e:
+            logger.error(f"Failed to download config: {e}")
+            return 
+            
+    if not config_path:
+        config_path = os.path.join(base_path, 'configs', 'default.json')
 
-def main(config_path=None, win11debloat_config_path=None):
-	if getattr(sys, 'frozen', False):
-		base_path = os.path.dirname(sys.executable)
-	else:
-		components_dir = os.path.dirname(os.path.abspath(__file__))
-		base_path = os.path.dirname(components_dir)
-	if config_path and isinstance(config_path, str) and _is_url(config_path):
-		try:
-			config_path = _download_config(config_path)
-		except Exception as e:
-			logger.error(f"Failed to download WinUtil config: {e}")
-			try:
-				show_error_popup(
-					f"Failed to download WinUtil config from URL.\n{e}",
-					allow_continue=False,
-				)
-			except Exception:
-				pass
-			sys.exit(1)
-	if not config_path:
-		config_path = os.path.join(base_path, 'configs', 'default.json')
-	if not os.path.exists(config_path):
-		logger.error(f"WinUtil config not found: {config_path}")
-		try:
-			show_error_popup(
-				f"WinUtil config not found:\n{config_path}",
-				allow_continue=False,
-			)
-		except Exception:
-			pass
-		sys.exit(1)
-	logger.info(f"Using WinUtil config: {config_path}")
-	winutil_path = os.path.join(base_path, 'external_scripts', 'winutil.ps1')
-	if not os.path.exists(winutil_path):
-		logger.error(f"Bundled WinUtil script not found: {winutil_path}")
-		try:
-			show_error_popup(
-				f"Bundled WinUtil script not found:\n{winutil_path}",
-				allow_continue=False
-			)
-		except Exception:
-			pass
-		sys.exit(1)
-	cmd1 = f"& '{winutil_path}' -Config '{config_path}' -Run -NoUI"
-	logger.info("Executing ChrisTitusTech WinUtil")
-	try:
-		run_powershell_command(
-			cmd1,
-			monitor_output=True,
-			termination_str='Tweaks are Finished',
-		)
-		logger.info("Successfully executed ChrisTitusTech WinUtil")
-	except Exception as e:
-		logger.error(f"Failed to execute ChrisTitusTech WinUtil: {e}")
-		try:
-			show_error_popup(
-				f"Failed to execute ChrisTitusTech WinUtil:\n{e}",
-				allow_continue=False,
-			)
-		except Exception:
-			pass
-		sys.exit(1)
-	win11debloat_path = os.path.join(base_path, 'external_scripts', 'Raphire-Win11Debloat-c523386', 'Win11Debloat.ps1')
-	if not os.path.exists(win11debloat_path):
-		logger.error(f"Bundled Win11Debloat script not found: {win11debloat_path}")
-		try:
-			show_error_popup(
-				f"Bundled Win11Debloat script not found:\n{win11debloat_path}",
-				allow_continue=False
-			)
-		except Exception:
-			pass
-		sys.exit(1)
+    if not os.path.exists(config_path):
+        logger.error(f"Config not found: {config_path}")
+        return
 
-	if not win11debloat_config_path:
-		win11debloat_config_path = os.path.join(base_path, 'configs', 'win11debloat_default.json')
+    logger.info(f"Using Config: {config_path}")
 
-	if not os.path.exists(win11debloat_config_path):
-		logger.error(f"Win11Debloat config not found: {win11debloat_config_path}")
-		try:
-			show_error_popup(
-				f"Win11Debloat config not found:\n{win11debloat_config_path}",
-				allow_continue=False
-			)
-		except Exception:
-			pass
-		sys.exit(1)
+    winutil_args_path = config_path 
+    win11debloat_args = [] 
 
-	try:
-		with open(win11debloat_config_path, 'r') as f:
-			args2 = json.load(f)
-		if not isinstance(args2, list):
-			raise ValueError("Config JSON must contain a list of arguments.")
-	except Exception as e:
-		logger.error(f"Failed to load Win11Debloat config: {e}")
-		try:
-			show_error_popup(
-				f"Failed to load Win11Debloat config:\n{e}",
-				allow_continue=False
-			)
-		except Exception:
-			pass
-		sys.exit(1)
+    default_w11_config = os.path.join(base_path, 'configs', 'win11debloat_default.json')
+    if os.path.exists(default_w11_config):
+        try:
+            with open(default_w11_config, 'r') as f:
+                win11debloat_args = json.load(f)
+        except Exception:
+            logger.warning("Failed to load default Win11Debloat config.")
 
-	flags = ' '.join(args2)
-	cmd2 = f"& '{win11debloat_path}' {flags}"
-	logger.info("Executing Raphi Win11Debloat")
-	try:
-		run_powershell_command(cmd2)
-		logger.info("Successfully executed Raphi Win11Debloat")
-	except Exception as e:
-		logger.error(f"Failed to execute Raphi Win11Debloat: {e}")
-		try:
-			show_error_popup(
-				f"Failed to execute Raphi Win11Debloat:\n{e}",
-				allow_continue=False
-			)
-		except Exception:
-			pass
-		sys.exit(1)
+    try:
+        with open(config_path, 'r', encoding='utf-8-sig') as f:
+            user_data = json.load(f)
+        
+        if isinstance(user_data, dict) and ("winutil" in user_data or "win11debloat" in user_data):
+            logger.info("Detected Unified Config format.")
+            
+            if "winutil" in user_data:
+                fd, temp_winutil_path = tempfile.mkstemp(prefix="talon_winutil_extracted_", suffix=".json")
+                with os.fdopen(fd, "w") as tmp:
+                    json.dump(user_data["winutil"], tmp, indent=4)
+                winutil_args_path = temp_winutil_path
+                logger.info(f"Extracted WinUtil config to: {winutil_args_path}")
+            
+            if "win11debloat" in user_data:
+                if isinstance(user_data["win11debloat"], list):
+                    win11debloat_args = user_data["win11debloat"]
+                    logger.info("Loaded custom Win11Debloat arguments.")
+    except Exception as e:
+        logger.warning(f"Error parsing config file ({e}). Treating as legacy WinUtil config.")
 
-	logger.info("All external debloat scripts executed successfully.")
+    winutil_script = os.path.join(base_path, 'external_scripts', 'winutil.ps1')
+    if os.path.exists(winutil_script):
+        cmd1 = f"& '{winutil_script}' -Config '{winutil_args_path}' -Run -NoUI"
+        logger.info("Executing ChrisTitusTech WinUtil")
+        try:
+            run_powershell_command(cmd1, monitor_output=True, termination_str='Tweaks are Finished')
+        except Exception as e:
+            logger.error(f"WinUtil execution failed: {e}")
 
-
+    win11debloat_script = os.path.join(base_path, 'external_scripts', 'Raphire-Win11Debloat-c523386', 'Win11Debloat.ps1')
+    if os.path.exists(win11debloat_script):
+        flags = ' '.join(win11debloat_args)
+        cmd2 = f"& '{win11debloat_script}' {flags}"
+        logger.info(f"Executing Raphi Win11Debloat with flags: {flags}")
+        try:
+            run_powershell_command(cmd2)
+        except Exception as e:
+            logger.error(f"Win11Debloat execution failed: {e}")
+            
+    logger.info("External scripts sequence complete.")
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/talon.py
+++ b/talon.py
@@ -78,12 +78,6 @@ def parse_args(argv=None):
 		metavar="PATH",
 		help="Pass a custom WinUtil configuration to use instead of the default Talon configuration.",
 	)
-	parser.add_argument(
-        "--win11debloat-config",
-        dest="win11debloat_config",
-        metavar="PATH",
-        help="Pass a custom JSON configuration file for Win11Debloat parameters.",
-    )
 	for slug, _, _ in DEBLOAT_STEPS:
 		dest = f"skip_{slug.replace('-', '_')}_step"
 		parser.add_argument(
@@ -227,7 +221,7 @@ def main(argv=None):
 			_update_status(bus, status_label, message)
 			try:
 				if func is debloat_execute_external_scripts.main:
-					func(args.config, args.win11debloat_config)
+					func(args.config)
 				else:
 					func()
 			except Exception:


### PR DESCRIPTION
Hey K0, following up on our email chat. This PR adds the ability to pass custom arguments to Win11Debloat, mirroring the logic used for `WinUtil`.

### What Changed
- Moved the hardcoded list of flags out of the python script and into `configs/win11debloat_default.json`.
-  Added `--win11debloat-config [PATH]` to `talon.py`.
-  Updated `debloat_execute_external_scripts.py` to load from the JSON config (default or custom) instead of the hardcoded list.

I implemented the logic based on the existing `WinUtil` patterns, but I haven't run a full build/install test on a Windows machine yet. A quick sanity check/dry run would be appreciated!