### PR TITLE
feat: check for OneDrive process and warn user (Fixes #217)

### DIFF
--- a/preinstall_components/pre_checks.py
+++ b/preinstall_components/pre_checks.py
@@ -62,9 +62,35 @@ def _run_test_script(script_path: str) -> bool:
     return False
 
 
+def _check_onedrive_running() -> None:
+    """Checks if OneDrive is running and warns the user."""
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FI", "IMAGENAME eq OneDrive.exe"],
+            capture_output=True,
+            text=True,
+            creationflags=(
+                subprocess.CREATE_NO_WINDOW
+                if hasattr(subprocess, "CREATE_NO_WINDOW")
+                else 0
+            ),
+        )
+        # tasklist output contains the image name if found
+        if "OneDrive.exe" in result.stdout:
+            logger.warning("OneDrive detected running.")
+            show_error_popup(
+                "OneDrive is currently running.\n\n"
+                "Running Talon while OneDrive is active may result in accidental data loss (Issue #217).\n"
+                "It is HIGHLY recommended that you sign out and close OneDrive completely before continuing.",
+                allow_continue=True,
+            )
+    except Exception as e:
+        logger.error(f"OneDrive check failed: {e}")
+
 
 def main() -> None:
     check_windows_11_home_or_pro()
+    _check_onedrive_running()
     _check_temp_writable()
 
 


### PR DESCRIPTION
Addresses Issue #217. Implements a pre-check to detect if `OneDrive.exe` is running.

- Added `_check_onedrive_running()` to `preinstall_components/pre_checks.py`.
- Uses `tasklist` to detect the process.
- Displays a warning popup advising the user to sign out/close OneDrive, preventing potential data syncing issues during debloat.